### PR TITLE
Adding ordering of use statements

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -2,5 +2,5 @@
 
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers(['-empty_return'])
+    ->fixers(['-empty_return', 'ordered_use'])
 ;


### PR DESCRIPTION
When this is merged, builds will soon start to fail as their .php_cs file is out of date with respect to this one.
