### PR TITLE
Add pipeline for building, testing and pushing an image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*.md
+vendor/

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,6 @@
+<?php
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers(['-empty_return', 'ordered_use'])
+;

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM elifesciences/php_cli
 USER elife
 RUN mkdir -p /srv/proofreader
 WORKDIR /srv/proofreader
-COPY composer.json /srv/proofreader/
+COPY --chown=elife:elife composer.json /srv/proofreader/
 RUN composer install --classmap-authoritative --no-dev
-COPY . /srv/proofreader
+COPY --chown=elife:elife . /srv/proofreader
 
 USER www-data
 CMD bin/proofreader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM elifesciences/php_cli
 
 USER elife
-RUN mkdir -p /srv/proofreader
-WORKDIR /srv/proofreader
-COPY --chown=elife:elife composer.json /srv/proofreader/
+RUN mkdir -p /srv/proofreader-php
+WORKDIR /srv/proofreader-php
+COPY --chown=elife:elife composer.json /srv/proofreader-php/
 RUN composer install --classmap-authoritative --no-dev
-COPY --chown=elife:elife . /srv/proofreader
+COPY --chown=elife:elife . /srv/proofreader-php
 
 USER www-data
 CMD bin/proofreader

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM elifesciences/php_cli
 USER elife
 RUN mkdir -p /srv/proofreader
 WORKDIR /srv/proofreader
-COPY composer.json composer.lock /srv/proofreader/
+COPY composer.json /srv/proofreader/
 RUN composer install --classmap-authoritative --no-dev
 COPY . /srv/proofreader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM elifesciences/php_cli
+
+USER elife
+RUN mkdir -p /srv/proofreader
+WORKDIR /srv/proofreader
+COPY composer.json composer.lock /srv/proofreader/
+RUN composer install --classmap-authoritative --no-dev
+COPY . /srv/proofreader
+
+USER www-data
+CMD bin/proofreader

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,7 @@ elifeLibrary {
 
     stage 'Smoke tests', {
         // runs proofreader on itself
-        // TODO: add src/
-        sh "docker run elifesciences/proofreader-php:${commit} bin/proofreader test/"
+        sh "docker run elifesciences/proofreader-php:${commit} bin/proofreader src/ test/"
     }
 
     elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+elifeLibrary {
+    def commit
+    stage 'Checkout', {
+        checkout scm
+        commit = elifeGitRevision()
+    }
+
+    def image
+    stage 'Build image', {
+        dockerBuild 'proofreader-php', commit
+        image = DockerImage.elifesciences(this, 'proofreader-php', commit)
+    }
+
+    stage 'Smoke tests', {
+        // runs proofreader on itself
+        // TODO: add src/
+        sh "docker run elifesciences/proofreader-php:${commit} bin/proofreader test/"
+    }
+
+    elifeMainlineOnly {
+        stage 'Push image', {
+            image.push()
+            image.tag('latest').push()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -51,16 +51,29 @@ Time: 43 ms, Memory: 4.00MB
 ## Containerization
 
 Execute `proofreader` against its test folder (not that useful):
+
 ```
 docker run elifesciences/proofreader-php /srv/proofreader/bin/proofreader test/
 ```
 
 Execute `proofreader` on the `src` folder of your own project:
+
 ```
 docker run -v $(pwd):/code elifesciences/proofreader-php /srv/proofreader/bin/proofreader /code/src
 ```
 
 Execute `php-cs-fixer` on the `src` folder of your own project (experimental):
+
 ```
 docker run -v $(pwd):/code -u $(id -u) elifesciences/proofreader-php /srv/proofreader/vendor/bin/php-cs-fixer fix /code/src
+```
+
+Import `proofreader` in another project's image:
+
+```
+FROM elifesciences/proofreader-php:latest AS proofreader
+...
+USER elife
+COPY --from=proofreader --chown=elife:elife /srv/proofreader /srv/proofreader
+RUN ln -s /srv/proofreader/bin/proofreader /srv/bin/proofreader
 ```

--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ phpcpd 2.0.4 by Sebastian Bergmann.
 Time: 43 ms, Memory: 4.00MB
 ```
 
+## Containerization
+
+Execute `proofreader` against its test folder (not that useful):
+```
+docker run elifesciences/proofreader-php /srv/proofreader/bin/proofreader test/
+```
+
+Execute `proofreader` on the `src` folder of your own project:
+```
+docker run -v $(pwd):/code elifesciences/proofreader-php /srv/proofreader/bin/proofreader /code/src
+```
+
+Execute `php-cs-fixer` on the `src` folder of your own project (experimental):
+```
+docker run -v $(pwd):/code -u $(id -u) elifesciences/proofreader-php /srv/proofreader/vendor/bin/php-cs-fixer fix /code/src
+```

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ Time: 43 ms, Memory: 4.00MB
 Execute `proofreader` against its test folder (not that useful):
 
 ```
-docker run elifesciences/proofreader-php /srv/proofreader/bin/proofreader test/
+docker run elifesciences/proofreader-php /srv/proofreader-php/bin/proofreader test/
 ```
 
 Execute `proofreader` on the `src` folder of your own project:
 
 ```
-docker run -v $(pwd):/code elifesciences/proofreader-php /srv/proofreader/bin/proofreader /code/src
+docker run -v $(pwd):/code elifesciences/proofreader-php /srv/proofreader-php/bin/proofreader /code/src
 ```
 
 Execute `php-cs-fixer` on the `src` folder of your own project (experimental):
 
 ```
-docker run -v $(pwd):/code -u $(id -u) elifesciences/proofreader-php /srv/proofreader/vendor/bin/php-cs-fixer fix /code/src
+docker run -v $(pwd):/code -u $(id -u) elifesciences/proofreader-php /srv/proofreader-php/vendor/bin/php-cs-fixer fix /code/src
 ```
 
 Import `proofreader` in another project's image:
@@ -74,6 +74,6 @@ Import `proofreader` in another project's image:
 FROM elifesciences/proofreader-php:latest AS proofreader
 ...
 USER elife
-COPY --from=proofreader --chown=elife:elife /srv/proofreader /srv/proofreader
-RUN ln -s /srv/proofreader/bin/proofreader /srv/bin/proofreader
+COPY --from=proofreader --chown=elife:elife /srv/proofreader-php /srv/proofreader-php
+RUN ln -s /srv/proofreader-php/bin/proofreader /srv/bin/proofreader
 ```

--- a/bin/proofreader
+++ b/bin/proofreader
@@ -20,8 +20,14 @@ function first_that_exists()
     done 
     exit 1
 }
-current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-parent_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+current_file="${BASH_SOURCE[0]}"
+if test -L "${current_file}"; then
+    resolved_file=$(readlink "${current_file}")
+else
+    resolved_file="${current_file}"
+fi
+current_dir="$( cd "$( dirname "${resolved_file}" )" && pwd )"
+parent_dir="$( cd "$( dirname "${resolved_file}" )" && cd .. && pwd )"
 local_checkout_dir=$parent_dir
 composer_installation_dir="${parent_dir}/elife/proofreader-php"
 dir=$(first_that_exists "${composer_installation_dir} ${local_checkout_dir}")

--- a/src/ForbiddenClassRule.php
+++ b/src/ForbiddenClassRule.php
@@ -2,9 +2,8 @@
 
 namespace eLife\Proofreader;
 
-class ForbiddenClassRule
-    extends \PHPMD\AbstractRule
-    implements \PHPMD\Rule\MethodAware,
+class ForbiddenClassRule extends \PHPMD\AbstractRule implements
+\PHPMD\Rule\MethodAware,
     \PHPMD\Rule\FunctionAware
 {
     public function apply(\PHPMD\AbstractNode $node)

--- a/src/ForbiddenPrefixRule.php
+++ b/src/ForbiddenPrefixRule.php
@@ -2,9 +2,8 @@
 
 namespace eLife\Proofreader;
 
-class ForbiddenPrefixRule
-    extends \PHPMD\AbstractRule
-    implements \PHPMD\Rule\ClassAware,
+class ForbiddenPrefixRule extends \PHPMD\AbstractRule implements
+\PHPMD\Rule\ClassAware,
     \PHPMD\Rule\InterfaceAware
 {
     public function apply(\PHPMD\AbstractNode $node)

--- a/src/ForbiddenSuffixRule.php
+++ b/src/ForbiddenSuffixRule.php
@@ -2,9 +2,8 @@
 
 namespace eLife\Proofreader;
 
-class ForbiddenSuffixRule
-    extends \PHPMD\AbstractRule
-    implements \PHPMD\Rule\ClassAware,
+class ForbiddenSuffixRule extends \PHPMD\AbstractRule implements
+\PHPMD\Rule\ClassAware,
     \PHPMD\Rule\InterfaceAware
 {
     public function apply(\PHPMD\AbstractNode $node)

--- a/src/MyRule.php
+++ b/src/MyRule.php
@@ -19,9 +19,7 @@ class MyRule extends \PHPMD\AbstractRule
 }
  */
 
-class MyRule extends \PHPMD\AbstractRule
-    implements \PHPMD\Rule\MethodAware,
-    \PHPMD\Rule\FunctionAware
+class MyRule extends \PHPMD\AbstractRule implements \PHPMD\Rule\MethodAware, \PHPMD\Rule\FunctionAware
 {
     public function apply(\PHPMD\AbstractNode $node)
     {


### PR DESCRIPTION
Incidentally, make also `proofreader` runnable from a symlink for the convenience of images copying `/srv/proofreader`.